### PR TITLE
Add env example and Express server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
-MONGODB_URI=mongodb://localhost:27017/your_db
-JWT_SECRET=your_jwt_secret
-PORT=3000
+MONGO_URI=
+JWT_SECRET=
+PORT=5000
+VITE_API_URL=http://localhost:5000
+OPENAI_API_KEY=

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,14 @@
+require('dotenv').config();
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Hidden Gems Los Angeles API');
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add environment example variables
- setup basic Express server using dotenv

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b28526d5c8332afbc571a997690b4