### PR TITLE
Add Express backend skeleton

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,10 +1,10 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
-    "dev": "node index.js",
-    "start": "node index.js"
+    "dev": "node src/index.js",
+    "start": "node src/index.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+require('dotenv').config();
+
+const { MONGO_URI, PORT } = process.env;
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+mongoose.connect(MONGO_URI)
+  .then(() => console.log('Connected to MongoDB'))
+  .catch(err => {
+    console.error('MongoDB connection error:', err);
+    process.exit(1);
+  });
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an Express server in `/backend/src/index.js`
- wire scripts in `backend/package.json` to start the new server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b28b0c064833289600bd8715e29dc