### PR TITLE
Add basic auth routes

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,9 +1,21 @@
 require('dotenv').config();
 const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+const authRoutes = require('./src/routes/auth');
 const app = express();
 const port = process.env.PORT || 3000;
 
+mongoose.connect(process.env.MONGO_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+}).then(() => console.log('MongoDB connected'))
+  .catch(err => console.error('MongoDB connection error:', err));
+
+app.use(cors());
 app.use(express.json());
+
+app.use('/api/auth', authRoutes);
 
 app.get('/', (req, res) => {
   res.send('Hidden Gems Los Angeles API');

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "bcrypt": "^5.1.0",
-    "jsonwebtoken": "^9.0.0"
+    "jsonwebtoken": "^9.0.0",
+    "express-validator": "^6.16.2"
   }
 }

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true }
+});
+
+module.exports = mongoose.model('User', userSchema);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,73 @@
+const express = require('express');
+const router = express.Router();
+const { body, validationResult } = require('express-validator');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+// POST /api/auth/register
+router.post('/register',
+  [
+    body('email').isEmail(),
+    body('password').isLength({ min: 6 })
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { email, password } = req.body;
+    try {
+      let user = await User.findOne({ email });
+      if (user) {
+        return res.status(400).json({ message: 'User already exists' });
+      }
+
+      const hashedPassword = await bcrypt.hash(password, 10);
+      user = new User({ email, password: hashedPassword });
+      await user.save();
+
+      const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET);
+      res.json({ token });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Server error' });
+    }
+  }
+);
+
+// POST /api/auth/login
+router.post('/login',
+  [
+    body('email').isEmail(),
+    body('password').isLength({ min: 6 })
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { email, password } = req.body;
+    try {
+      const user = await User.findOne({ email });
+      if (!user) {
+        return res.status(400).json({ message: 'Invalid credentials' });
+      }
+
+      const isMatch = await bcrypt.compare(password, user.password);
+      if (!isMatch) {
+        return res.status(400).json({ message: 'Invalid credentials' });
+      }
+
+      const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET);
+      res.json({ token });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Server error' });
+    }
+  }
+);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add user model and auth routes with register/login
- connect to MongoDB and mount auth router
- add `express-validator` dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b290b39f88332be9675fb0d86ef45