### PR TITLE
Initialize Vite React PWA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+frontend/dist/

--- a/frontend/build-sw.js
+++ b/frontend/build-sw.js
@@ -1,0 +1,13 @@
+const { injectManifest } = require('workbox-build');
+
+injectManifest({
+  swSrc: 'service-worker.js',
+  swDest: 'dist/service-worker.js',
+  globDirectory: 'dist',
+  globPatterns: ['**/*.{js,css,html,png,svg,ico,json}']
+}).then(({ count, size, warnings }) => {
+  if (warnings.length) {
+    console.warn(warnings);
+  }
+  console.log(`Generated service-worker.js, which will precache ${count} files, totaling ${size} bytes.`);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#ffffff" />
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" href="/icons/icon-192x192.png" type="image/png" />
+    <title>Hidden Gems LA</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Hidden Gems LA",
+  "short_name": "GemsLA",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,12 +3,19 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "vite",
-    "start": "vite build && vite preview"
+    "build": "vite build",
+    "preview": "vite preview",
+    "build-sw": "node build-sw.js",
+    "start": "npm run build && npm run build-sw && vite preview"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "vite": "^4.0.0",
     "pixi.js": "^7.2.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "workbox-build": "^6.5.4"
   }
 }

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -1,0 +1,2 @@
+import { precacheAndRoute } from 'workbox-precaching';
+precacheAndRoute(self.__WB_MANIFEST || []);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <h1>Hidden Gems Los Angeles</h1>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up a Vite + React project in `frontend`
- add PWA manifest
- create service worker and Workbox build script
- configure Vite with React plugin
- update package.json with Workbox and React plugin
- add `.gitignore`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build-sw` *(fails: Cannot find module 'workbox-build')*

------
https://chatgpt.com/codex/tasks/task_e_685b298d40088332ab8bc30147f4f027