### PR TITLE
Add level API and basic GameBoard component

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hidden Gems LA</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,5 +10,8 @@
     "react-dom": "^18.2.0",
     "vite": "^4.0.0",
     "pixi.js": "^7.2.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }

--- a/frontend/src/api/levels.js
+++ b/frontend/src/api/levels.js
@@ -1,0 +1,21 @@
+export async function getLevelConfig(id) {
+  const response = await fetch(`/api/levels/${id}`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch level configuration');
+  }
+  return response.json();
+}
+
+export async function postLevelResult({ levelId, score, userId }) {
+  const response = await fetch(`/api/levels/${levelId}/result`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ score, userId })
+  });
+  if (!response.ok) {
+    throw new Error('Failed to post level result');
+  }
+  return response.json();
+}

--- a/frontend/src/components/GameBoard.jsx
+++ b/frontend/src/components/GameBoard.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { getLevelConfig, postLevelResult } from '../api/levels';
+
+const GameBoard = ({ levelId, userId }) => {
+  const [config, setConfig] = useState(null);
+  const [completed, setCompleted] = useState(false);
+
+  useEffect(() => {
+    getLevelConfig(levelId)
+      .then(setConfig)
+      .catch((err) => console.error(err));
+  }, [levelId]);
+
+  const handleComplete = async (score) => {
+    try {
+      await postLevelResult({ levelId, score, userId });
+      setCompleted(true);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (!config) return <div>Loading...</div>;
+
+  return (
+    <div>
+      {/* Render game board based on config here */}
+      {completed ? (
+        <div>Level Completed!</div>
+      ) : (
+        <button onClick={() => handleComplete(100)}>Complete Level</button>
+      )}
+    </div>
+  );
+};
+
+export default GameBoard;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import GameBoard from './components/GameBoard';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <GameBoard levelId={1} userId={1} />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- implement `getLevelConfig` and `postLevelResult` API helpers
- create `GameBoard` React component that loads level config on mount and posts results
- scaffold simple Vite React frontend files

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `npm run lint --prefix frontend` *(fails: Missing script)*
- `npm run dev --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b29a7769c833290fccd6564e4e72d