### PR TITLE
Add linting, husky and tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky:debug $*"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+  export readonly husky_skip_init=1
+  sh -e "$(dirname "$0")/../$hook_name" "$@"
+  exitCode="$?"
+  debug "$hook_name hook exited with code $exitCode (dry-run: $HUSKY_DRY_RUN)"
+  if [ "$HUSKY_DRY_RUN" = "1" ]; then
+    exit 0
+  else
+    exit "$exitCode"
+  fi
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # hidden_gems_losangeles
-Se propone un juego web de rompecabezas tipo match-3 (estilo Candy Crush Saga) inspirado en la cuenta Hidden Gems Los Angeles, que destaca secretos culturales, gastronómicos y eventos únicos de LA. El objetivo es crear una experiencia lúdica que combine la jugabilidad adictiva de Candy Crush con el contenido de Hidden Gems LA, 
+Se propone un juego web de rompecabezas tipo match-3 (estilo Candy Crush Saga) inspirado en la cuenta Hidden Gems Los Angeles, que destaca secretos culturales, gastronómicos y eventos únicos de LA. El objetivo es crear una experiencia lúdica que combine la jugabilidad adictiva de Candy Crush con el contenido de Hidden Gems LA.
+
+## Ejecución local
+
+```bash
+docker-compose up
+cd backend && npm run dev
+cd ../frontend && npm run dev
+```
+
+Luego visita [http://localhost:3000](http://localhost:3000).

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/backend/.prettierrc
+++ b/backend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,1 @@
+export { default } from '../eslint.config.js';

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "main": "src/index.js",
   "scripts": {
     "dev": "node src/index.js",
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -14,5 +15,11 @@
     "bcrypt": "^5.1.0",
     "jsonwebtoken": "^9.0.0",
     "express-validator": "^6.16.2"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3",
+    "eslint": "^8.54.0",
+    "prettier": "^3.0.0"
   }
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3,24 +3,32 @@ const mongoose = require('mongoose');
 const cors = require('cors');
 require('dotenv').config();
 
-const { MONGO_URI, PORT } = process.env;
+const { MONGO_URI, PORT = 5000 } = process.env;
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 
-mongoose.connect(MONGO_URI)
-  .then(() => console.log('Connected to MongoDB'))
-  .catch(err => {
-    console.error('MongoDB connection error:', err);
-    process.exit(1);
-  });
+if (process.env.NODE_ENV !== 'test') {
+  mongoose
+    .connect(MONGO_URI)
+    .then(() => console.log('Connected to MongoDB'))
+    .catch((err) => {
+      console.error('MongoDB connection error:', err);
+      process.exit(1);
+    });
+}
 
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../src/index');
+
+describe('GET /api/health', () => {
+  it('returns status ok', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+export default [
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    ignores: ['node_modules/**'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module'
+    },
+    plugins: {},
+    rules: {
+    }
+  }
+];

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.eslintrc.json"
+}

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,1 @@
+export { default } from '../eslint.config.js';

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "build-sw": "node build-sw.js",
-    "start": "npm run build && npm run build-sw && vite preview"
+    "start": "npm run build && npm run build-sw && vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -15,11 +16,10 @@
     "pixi.js": "^7.2.4"
   },
   "devDependencies": {
- s1ja1p-codex/escribir-funciones-fetch-en-levels.js
-    "@vitejs/plugin-react": "^4.0.0"
-
     "@vitejs/plugin-react": "^4.0.0",
-    "workbox-build": "^6.5.4"
- main
+    "workbox-build": "^6.5.4",
+    "jest": "^29.6.1",
+    "eslint": "^8.54.0",
+    "prettier": "^3.0.0"
   }
 }

--- a/frontend/src/utils/match3.js
+++ b/frontend/src/utils/match3.js
@@ -1,0 +1,42 @@
+export function findMatches(board) {
+  const matches = [];
+  const height = board.length;
+  const width = board[0].length;
+  // horizontal
+  for (let y = 0; y < height; y++) {
+    let count = 1;
+    for (let x = 1; x <= width; x++) {
+      if (x < width && board[y][x] === board[y][x - 1]) {
+        count++;
+      } else {
+        if (count >= 3) {
+          for (let k = 0; k < count; k++) {
+            matches.push({ x: x - 1 - k, y });
+          }
+        }
+        count = 1;
+      }
+    }
+  }
+  // vertical
+  for (let x = 0; x < width; x++) {
+    let count = 1;
+    for (let y = 1; y <= height; y++) {
+      if (y < height && board[y][x] === board[y - 1][x]) {
+        count++;
+      } else {
+        if (count >= 3) {
+          for (let k = 0; k < count; k++) {
+            matches.push({ x, y: y - 1 - k });
+          }
+        }
+        count = 1;
+      }
+    }
+  }
+  const unique = {};
+  matches.forEach(m => {
+    unique[`${m.x}-${m.y}`] = m;
+  });
+  return Object.values(unique);
+}

--- a/frontend/tests/match3.test.js
+++ b/frontend/tests/match3.test.js
@@ -1,0 +1,36 @@
+const { findMatches } = require('../src/utils/match3');
+
+describe('findMatches', () => {
+  test('detects horizontal matches', () => {
+    const board = [
+      ['a', 'a', 'a'],
+      ['b', 'c', 'd'],
+      ['e', 'f', 'g'],
+    ];
+    const result = findMatches(board);
+    expect(result).toContainEqual({ x: 0, y: 0 });
+    expect(result).toContainEqual({ x: 1, y: 0 });
+    expect(result).toContainEqual({ x: 2, y: 0 });
+  });
+
+  test('detects vertical matches', () => {
+    const board = [
+      ['a', 'b', 'c'],
+      ['a', 'd', 'e'],
+      ['a', 'f', 'g'],
+    ];
+    const result = findMatches(board);
+    expect(result).toContainEqual({ x: 0, y: 0 });
+    expect(result).toContainEqual({ x: 0, y: 1 });
+    expect(result).toContainEqual({ x: 0, y: 2 });
+  });
+
+  test('returns empty when no matches', () => {
+    const board = [
+      ['a', 'b', 'c'],
+      ['d', 'e', 'f'],
+      ['g', 'h', 'i'],
+    ];
+    expect(findMatches(board)).toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hidden-gems-monorepo",
+  "private": true,
+  "scripts": {
+    "prepare": "husky install"
+  },
+  "lint-staged": {
+    "*.{js,jsx}": "eslint --fix"
+  },
+  "devDependencies": {
+    "husky": "^8.0.0",
+    "lint-staged": "^13.0.0",
+    "eslint": "^8.54.0",
+    "prettier": "^3.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up ESLint/Prettier configs in repo, backend and frontend
- install husky with lint-staged pre-commit hook
- export express app for testing and skip DB on `NODE_ENV=test`
- add Jest configs and tests for health endpoint and match-3 logic
- document how to run the app locally

## Testing
- `npx eslint backend/src/index.js`
- `npm test` (fails: `jest: not found`)
- `npm test` in frontend (fails: `jest: not found`)


------
https://chatgpt.com/codex/tasks/task_e_685b2c277c388332aeb900401e098fc1