### PR TITLE
Add Header with Instagram auth and PWA install prompt

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,19 +5,24 @@ import MapPage from './pages/MapPage';
 import GameBoard from './pages/GameBoard';
 import GemDetail from './pages/GemDetail';
 import ProfilePage from './pages/ProfilePage';
+import Header from './components/Header';
+import { InstagramAuthProvider } from './context/InstagramAuthContext';
 import './App.css';
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/avatar" element={<AvatarSelector />} />
-        <Route path="/map" element={<MapPage />} />
-        <Route path="/play/:zone/:level" element={<GameBoard />} />
-        <Route path="/gem/:id" element={<GemDetail />} />
-        <Route path="/profile" element={<ProfilePage />} />
-      </Routes>
-    </BrowserRouter>
+    <InstagramAuthProvider>
+      <BrowserRouter>
+        <Header />
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/avatar" element={<AvatarSelector />} />
+          <Route path="/map" element={<MapPage />} />
+          <Route path="/play/:zone/:level" element={<GameBoard />} />
+          <Route path="/gem/:id" element={<GemDetail />} />
+          <Route path="/profile" element={<ProfilePage />} />
+        </Routes>
+      </BrowserRouter>
+    </InstagramAuthProvider>
   );
 }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,76 @@
+import { useState, useEffect, useContext } from 'react';
+import { InstagramAuthContext } from '../context/InstagramAuthContext';
+
+export default function Header() {
+  const { setToken } = useContext(InstagramAuthContext);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [deferredPrompt, setDeferredPrompt] = useState(null);
+
+  useEffect(() => {
+    const handler = (e) => {
+      e.preventDefault();
+      setDeferredPrompt(e);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+    if (token) {
+      setToken(token);
+      const url = new URL(window.location);
+      url.searchParams.delete('token');
+      window.history.replaceState({}, '', url);
+    }
+  }, [setToken]);
+
+  const handleInstall = () => {
+    if (deferredPrompt) {
+      deferredPrompt.prompt();
+    }
+  };
+
+  const handleLogin = () => {
+    const clientId = 'YOUR_CLIENT_ID';
+    const redirectUri = window.location.origin;
+    const authUrl = `https://api.instagram.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=token`;
+    window.location.href = authUrl;
+  };
+
+  return (
+    <header className="flex items-center justify-between p-4 bg-darkBg text-white">
+      <div className="font-header font-black text-solarYellow text-xl">
+        Hidden Gems LA
+      </div>
+      <nav
+        className={`${
+          menuOpen ? 'block' : 'hidden'
+        } md:flex md:items-center md:space-x-4`}
+      >
+        <a href="/play" className="block px-3 py-2 hover:text-solarYellow">
+          Jugar
+        </a>
+        <button
+          onClick={handleInstall}
+          className="block px-3 py-2 hover:text-solarYellow"
+        >
+          Instalar App
+        </button>
+        <button
+          onClick={handleLogin}
+          className="block px-3 py-2 hover:text-solarYellow"
+        >
+          Login con Instagram
+        </button>
+      </nav>
+      <button
+        className="md:hidden text-solarYellow text-2xl"
+        onClick={() => setMenuOpen(!menuOpen)}
+      >
+        &#9776;
+      </button>
+    </header>
+  );
+}

--- a/frontend/src/context/InstagramAuthContext.jsx
+++ b/frontend/src/context/InstagramAuthContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useState } from 'react';
+
+export const InstagramAuthContext = createContext({
+  token: null,
+  setToken: () => {}
+});
+
+export function InstagramAuthProvider({ children }) {
+  const [token, setToken] = useState(null);
+  return (
+    <InstagramAuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </InstagramAuthContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- create `InstagramAuthContext` to store OAuth token
- add `Header` component with logo, play button, install and login actions
- update `App` to use new context and header

## Testing
- `npm test` in `frontend` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860672588648332b68258af879b46d4