### PR TITLE
Implement user profile page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "pixi.js": "^7.2.4",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "recharts": "^2.8.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,3 +1,82 @@
+import { useEffect, useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { InstagramAuthContext } from '../context/InstagramAuthContext';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip
+} from 'recharts';
+
 export default function ProfilePage() {
-  return <div>Profile Page</div>;
+  const navigate = useNavigate();
+  const { setToken } = useContext(InstagramAuthContext);
+  const [profile, setProfile] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/user/profile')
+      .then((res) => res.json())
+      .then((data) => setProfile(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  const logout = () => {
+    setToken(null);
+    navigate('/');
+  };
+
+  if (!profile) {
+    return <div className="p-4">Cargando...</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4 bg-white text-darkBg">
+      <img
+        src={`/api/avatars/${profile.avatar}`}
+        alt="Avatar"
+        className="w-32 h-32 rounded-full object-cover mx-auto"
+      />
+
+      <div>
+        <h2 className="font-header font-semibold text-lg mb-2">Gemas encontradas</h2>
+        <ul className="list-disc list-inside space-y-1">
+          {profile.gemsFound.map((g) => (
+            <li key={g}>{g.toLowerCase()}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div>
+        <h2 className="font-header font-semibold text-lg mb-2">Boosters</h2>
+        <div className="space-x-2">
+          {profile.boosters.map((b) => (
+            <span
+              key={b}
+              className="inline-block bg-neonPink text-white px-2 py-1 rounded-full text-sm"
+            >
+              {b}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h2 className="font-header font-semibold text-lg mb-2">Progreso</h2>
+        <BarChart width={300} height={200} data={profile.playStats}>
+          <XAxis dataKey="date" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="levelsCompleted" fill="#F5DF4D" />
+        </BarChart>
+      </div>
+
+      <button
+        onClick={logout}
+        className="px-4 py-2 bg-neonPink text-white rounded font-header"
+      >
+        Cerrar sesión
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- flesh out the `ProfilePage` with server fetch logic
- display gems and boosters and show progress chart using Recharts
- add logout button
- declare `recharts` dependency in the frontend package

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a2f13c308332877a502a63ec905e