### PR TITLE
Add Docker services with network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,50 +1,33 @@
-codex/crear-archivo-docker-compose.yml-con-3-servicios
 version: '3.9'
 services:
   backend:
-    build:
-      context: ./backend
-    volumes:
-      - ./backend:/app
+    build: ./backend
+    env_file:
+      - .env
     ports:
-      - '5000:5000'
+      - "4000:4000"
     networks:
-      - internal
+      - privacy_net
+
   frontend:
-    build:
-      context: ./frontend
-    volumes:
-      - ./frontend:/app
+    build: ./frontend
+    env_file:
+      - .env
     ports:
-      - '3000:3000'
+      - "3000:3000"
     networks:
-      - internal
+      - privacy_net
+
   mongodb:
     image: mongo:6
     volumes:
-      - mongo-data:/data/db
+      - data:/data/db
     networks:
-      - internal
-
-volumes:
-  mongo-data:
+      - privacy_net
 
 networks:
-  internal:
+  privacy_net:
     internal: true
 
-version: '3'
-services:
-  backend:
-    build: ./backend
-    container_name: backend
-    ports:
-      - "3000:3000"
-    env_file:
-      - .env
-  frontend:
-    build: ./frontend
-    container_name: frontend
-    ports:
-      - "5173:5173"
- main
+volumes:
+  data:


### PR DESCRIPTION
## Summary
- rewrite `docker-compose.yml` to include backend, frontend, and MongoDB services
- add internal network `privacy_net` and `data` volume

## Testing
- `npm test` *(fails: missing test script)*
- `cd backend && npm test` *(fails: jest not found)*
- `cd ../frontend && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd81529548332bcfbdf6491125192