### PR TITLE
Implement main Express server

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,15 +1,28 @@
+const path = require('path');
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
 const levelRoutes = require('./routes/levels');
-require('dotenv').config();
+const authRoutes = require('./routes/auth');
+const consentRoutes = require('./routes/consent');
+const policiesRoutes = require('./routes/policies');
+const dsarRoutes = require('./routes/dsar');
+const adminRoutes = require('./routes/admin');
 
-const { MONGO_URI, PORT = 5000 } = process.env;
+require('dotenv').config({ path: path.join(__dirname, '../config/.env') });
+
+const { MONGO_URI, PORT } = process.env;
+const SERVER_PORT = PORT || 4000;
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
+app.use('/api/auth', authRoutes);
+app.use('/api/consent', consentRoutes);
+app.use('/api/policies', policiesRoutes);
+app.use('/api/dsar', dsarRoutes);
+app.use('/api/admin', adminRoutes);
 app.use('/api/levels', levelRoutes);
 
 if (process.env.NODE_ENV !== 'test') {
@@ -28,8 +41,8 @@ app.get('/api/health', (req, res) => {
 
 
 if (process.env.NODE_ENV !== 'test') {
-  app.listen(PORT, () => {
-    console.log(`Server listening on port ${PORT}`);
+  app.listen(SERVER_PORT, () => {
+    console.log(`Server listening on port ${SERVER_PORT}`);
   });
 }
 

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,0 +1,3 @@
+const express = require('express');
+const router = express.Router();
+module.exports = router;

--- a/backend/src/routes/consent.js
+++ b/backend/src/routes/consent.js
@@ -1,0 +1,3 @@
+const express = require('express');
+const router = express.Router();
+module.exports = router;

--- a/backend/src/routes/dsar.js
+++ b/backend/src/routes/dsar.js
@@ -1,0 +1,3 @@
+const express = require('express');
+const router = express.Router();
+module.exports = router;

--- a/backend/src/routes/policies.js
+++ b/backend/src/routes/policies.js
@@ -1,0 +1,3 @@
+const express = require('express');
+const router = express.Router();
+module.exports = router;


### PR DESCRIPTION
## Summary
- configure dotenv from `./config/.env`
- add minimal routes for auth, consent, policies, dsar and admin
- register the new routes and default `/api/health`
- listen on `process.env.PORT` or 4000

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bdaf1dd588332b73879c1006e941d