### PR TITLE
Add auth middleware and secure level results

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,23 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+module.exports = async function (req, res, next) {
+  const authHeader = req.header('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'No token provided' });
+  }
+
+  const token = authHeader.replace('Bearer ', '');
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await User.findById(decoded.id).select('-passwordHash');
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid token user' });
+    }
+    req.user = user;
+    next();
+  } catch (err) {
+    console.error(err);
+    res.status(401).json({ message: 'Token is not valid' });
+  }
+};

--- a/backend/src/routes/levels.js
+++ b/backend/src/routes/levels.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
+const auth = require('../middleware/auth');
 
 // POST /api/levels/:id/result
-router.post('/:id/result', (req, res) => {
+router.post('/:id/result', auth, (req, res) => {
   // In a real app we would store the result in DB
   res.json({ success: true, level: req.params.id });
 });

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const app = require('../src/index');
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 
 describe('GET /api/health', () => {
   it('returns status ok', async () => {

--- a/backend/tests/levels.test.js
+++ b/backend/tests/levels.test.js
@@ -1,9 +1,14 @@
 const request = require('supertest');
 const app = require('../src/index');
+const jwt = require('jsonwebtoken');
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'testsecret';
 
 describe('POST /api/levels/:id/result', () => {
   it('returns success true', async () => {
-    const res = await request(app).post('/api/levels/1/result');
+    const token = jwt.sign({ id: 'user1' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .post('/api/levels/1/result')
+      .set('Authorization', `Bearer ${token}`);
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({ success: true, level: '1' });
   });


### PR DESCRIPTION
## Summary
- implement auth middleware to verify JWT and attach user
- secure level result endpoint with the new middleware
- adjust tests to supply auth tokens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c38345bd0833295c5df6418b18c78