### PR TITLE
Add policies and consent endpoints

### DIFF
--- a/backend/src/routes/consent.js
+++ b/backend/src/routes/consent.js
@@ -1,3 +1,40 @@
 const express = require('express');
 const router = express.Router();
+const auth = require('../middleware/auth');
+const Consent = require('../models/Consent');
+
+// POST /api/consent
+router.post('/', auth, async (req, res) => {
+  const { categories } = req.body;
+  try {
+    let consent = await Consent.findOne({ userId: req.user.id });
+    if (consent) {
+      consent.categories = categories;
+      consent.timestamp = new Date();
+      await consent.save();
+    } else {
+      consent = new Consent({ userId: req.user.id, categories });
+      await consent.save();
+    }
+    res.json(consent);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// GET /api/consent
+router.get('/', auth, async (req, res) => {
+  try {
+    const consent = await Consent.findOne({ userId: req.user.id });
+    if (!consent) {
+      return res.status(404).json({ message: 'Consent not found' });
+    }
+    res.json(consent);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
 module.exports = router;

--- a/backend/src/routes/policies.js
+++ b/backend/src/routes/policies.js
@@ -1,3 +1,42 @@
 const express = require('express');
 const router = express.Router();
+const auth = require('../middleware/auth');
+const Policy = require('../models/Policy');
+
+// GET /api/policies?region=CA&lang=es
+router.get('/', async (req, res) => {
+  const { region, lang } = req.query;
+  try {
+    const policy = await Policy.findOne({ region, lang })
+      .sort({ version: -1 });
+    if (!policy) {
+      return res.status(404).json({ message: 'Policy not found' });
+    }
+    res.json(policy);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// PUT /api/policies (admin)
+router.put('/', auth, async (req, res) => {
+  if (req.user.role !== 'admin') {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  const { region, lang, content } = req.body;
+  try {
+    const latest = await Policy.findOne({ region, lang })
+      .sort({ version: -1 });
+    const version = latest ? latest.version + 1 : 1;
+    const policy = new Policy({ region, lang, content, version });
+    await policy.save();
+    res.status(201).json(policy);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- implement GET and PUT endpoints for policies
- implement POST and GET endpoints for consent

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c42bb28e08332ade78c40bf2fe058